### PR TITLE
Remove lodash as dependency from prod build

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,15 +67,15 @@
     "ts-loader": "^6.2.1",
     "typescript": "3.7.2",
     "webpack": "^4.41.3",
-    "yarn-run-all": "^3.1.1"
+    "yarn-run-all": "^3.1.1",
+    "lodash": "^4.17.15"
   },
   "peerDependencies": {
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },
   "dependencies": {
-    "classnames": "^2.2.6",
-    "lodash": "^4.17.15"
+    "classnames": "^2.2.6"
   },
   "scripts": {
     "start": "parcel serve -d lib -p 3000 src/_demo/index.html",

--- a/src/pin-field/pin-field.tsx
+++ b/src/pin-field/pin-field.tsx
@@ -1,8 +1,5 @@
 import React, {FC, forwardRef, useCallback, useImperativeHandle, useRef} from "react"
 import classNames from "classnames"
-import noop from "lodash/fp/noop"
-import omit from "lodash/fp/omit"
-import range from "lodash/fp/range"
 
 import useMVU from "../mvu"
 import {getKeyFromKeyboardEvent, getKeyFromInputEvent} from "../kb-event"
@@ -16,6 +13,17 @@ import {
   PinFieldAction as Action,
   PinFieldEffect as Effect,
 } from "./pin-field.types"
+
+const noop = () => undefined
+const range = (start: number, end: number) => Array.from({length: end}, (_, i) => i + start)
+const omit = (keys: string[], obj: Record<string, any>): Record<string, any> => {
+  const poppedKey = keys.pop()
+  if (!poppedKey) {
+    return obj
+  }
+  const {[poppedKey]: omitted, ...rest} = obj
+  return omit(keys, rest)
+}
 
 export const NO_EFFECT: Effect[] = []
 export const PROP_KEYS = ["autoFocus", "className", "length", "validate", "format", "style"]


### PR DESCRIPTION
Lodash is very useful but also is pretty massive to bundle. The use case of lodash here could be replaced by simple functions. This resulted in a package size that was **73 KB smaller**.

### Demo page WITH lodash (217 KB)
<img width="354" alt="bild" src="https://user-images.githubusercontent.com/846688/94817434-49851600-03fd-11eb-8fda-d1e3aedd5e14.png">

### Demo page WITHOUT lodash (144 KB)
<img width="359" alt="bild" src="https://user-images.githubusercontent.com/846688/94817375-3c682700-03fd-11eb-95d1-6c1f9a30cd6d.png">
