### PR TITLE
Updated index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,10 +77,12 @@ export const ReactPinField: FC<Props> = forwardRef((customProps, fwdRef) => {
       ref.current.addEventListener("complete", handleComplete);
 
       return () => {
-        ref.current.removeEventListener("change", handleChange);
-        ref.current.removeEventListener("resolve-key", handleResolveKey);
-        ref.current.removeEventListener("reject-key", handleRejectKey);
-        ref.current.removeEventListener("complete", handleComplete);
+        if (ref.current) {
+          ref.current.removeEventListener("change", handleChange);
+          ref.current.removeEventListener("resolve-key", handleResolveKey);
+          ref.current.removeEventListener("reject-key", handleRejectKey);
+          ref.current.removeEventListener("complete", handleComplete);
+        }
       };
     }
     return;


### PR DESCRIPTION
Added an if statement to the useEffect hook's return statement function to check if ref.current exists before removing its event listeners. I had this issue where my page component updated, removing the ReactPinField component and it raised an error saying that ref.current is null. Changing the code to this fixed it. Since the ReactPinField  component is itself removed, there is no need to remove its event listeners as they'll automatically be removed by the garbage collector. (I hope my understanding is correct)