### PR TITLE
fix: preserve value when re-rendering

### DIFF
--- a/src/pin-field.tsx
+++ b/src/pin-field.tsx
@@ -40,7 +40,6 @@ export const PinField = forwardRef<HTMLInputElement[], Props>(
 
     function handleKeyDownAt(index: number): KeyboardEventHandler<HTMLInputElement> {
       return event => {
-        console.log("keyDown", index, event);
         const { key, code, keyCode, which } = event;
         dispatch({ type: "handle-key-down", index, key, code, keyCode, which });
       };
@@ -144,6 +143,7 @@ export const PinField = forwardRef<HTMLInputElement[], Props>(
         {...nativeProps}
         key={index}
         ref={setRefAt(index)}
+        value={index in state.values ? state.values[index] : ""}
         autoFocus={index === 0 && autoFocus}
         onKeyDown={handleKeyDownAt(index)}
         onChange={handleChangeAt(index)}


### PR DESCRIPTION
* Fixes issue: https://github.com/soywod/react-pin-field/issues/96
* Also, I removed a rogue `console.log` statement that I assume wasn't meant to be committed to master.

### Issue Summary
I've found that if the component is re-rendered, the internal state remains but the fields are cleared. And if you try to enter new values, the old values reappear.

https://github.com/user-attachments/assets/771163b1-0b5c-40ad-98f2-5666156349a0

### Fix
To fix this, the field component explicitly sets the `value` attribute on the `<input />` element on render. This way, if the component is re-rendered, it will still display the internal state.
